### PR TITLE
Re-download missing MSI files

### DIFF
--- a/src/Chauffeur.Jenkins/Services/ChauffeurService.cs
+++ b/src/Chauffeur.Jenkins/Services/ChauffeurService.cs
@@ -141,15 +141,17 @@ namespace Chauffeur.Jenkins.Services
                 var package = packages.FirstOrDefault(o => o.Job.Equals(jobName, StringComparison.OrdinalIgnoreCase));
                 if (package != null)
                 {
-                    Log.Info(this, "Uninstalling {0} package(s).", package.Paths.Length);
-                   
-                    if (package.Paths.Any(o => !File.Exists(o)))
+                    string[] paths = package.Paths;
+
+                    if (paths.Any(o => !File.Exists(o)))
                     {
                         var build = await this.GetBuildAsync(package.Job, package.BuildNumber.ToString(CultureInfo.InvariantCulture));
-                        await this.DownloadPackagesAsync(build);
+                        paths = await this.DownloadPackagesAsync(build);
                     }
 
-                    foreach (var pkg in package.Paths)
+                    Log.Info(this, "Uninstalling {0} package(s).", paths.Length);
+
+                    foreach (var pkg in paths)
                     {
                         this.UninstallPackage(pkg);
                     }
@@ -290,13 +292,7 @@ namespace Chauffeur.Jenkins.Services
         /// </returns>
         private void InstallPackage(string package)
         {
-            ProcessStartInfo startInfo = new ProcessStartInfo("cmd.exe", string.Format("/c start /MIN /wait msiexec.exe /i \"{0}\" /quiet {1}", package, this.Configuration.InstallPropertyReferences));
-            startInfo.WindowStyle = ProcessWindowStyle.Hidden;
-
-            Log.Info(this, string.Format("\t{0} {1}", startInfo.FileName, startInfo.Arguments));
-
-            using (Process process = Process.Start(startInfo))
-                if (process != null) process.WaitForExit();
+            MsiExecPackage(string.Format("/c start /MIN /wait msiexec.exe /i \"{0}\" /quiet {1}", package, this.Configuration.InstallPropertyReferences));
         }
 
         /// <summary>
@@ -310,6 +306,40 @@ namespace Chauffeur.Jenkins.Services
             foreach (var pkg in packages)
             {
                 this.InstallPackage(pkg);
+            }
+        }
+
+        /// <summary>
+        ///     Runs the msiexec executable that is used to install and uninstall the packages.
+        /// </summary>
+        /// <param name="arguments">The arguments.</param>
+        private void MsiExecPackage(string arguments)
+        {
+            ProcessStartInfo startInfo = new ProcessStartInfo("cmd.exe", arguments);
+            startInfo.WindowStyle = ProcessWindowStyle.Hidden;
+            startInfo.RedirectStandardError = true;
+            startInfo.RedirectStandardOutput = true;
+
+            Log.Info(this, string.Format("\t{0} {1}", startInfo.FileName, startInfo.Arguments));
+
+            using (Process process = Process.Start(startInfo))
+            {
+                if (process != null)
+                {
+                    using (StreamReader reader = process.StandardOutput)
+                    {
+                        string result = reader.ReadToEnd();
+                        Log.Info(this, string.Format("\t{0}", result));
+                    }
+
+                    using (StreamReader reader = process.StandardError)
+                    {
+                        string result = reader.ReadToEnd();
+                        Log.Error(this, string.Format("\t{0}", result));
+                    }
+
+                    process.WaitForExit();
+                }
             }
         }
 
@@ -350,13 +380,7 @@ namespace Chauffeur.Jenkins.Services
         /// </returns>
         private void UninstallPackage(string package)
         {
-            ProcessStartInfo startInfo = new ProcessStartInfo("cmd.exe", string.Format("/c start /MIN /wait msiexec.exe /x \"{0}\" /quiet {1}", package, this.Configuration.UninstallPropertyReferences));
-            startInfo.WindowStyle = ProcessWindowStyle.Hidden;
-
-            Log.Info(this, string.Format("\t{0} {1}", startInfo.FileName, startInfo.Arguments));
-
-            using (Process process = Process.Start(startInfo))
-                if (process != null) process.WaitForExit();
+            MsiExecPackage(string.Format("/c start /MIN /wait msiexec.exe /x \"{0}\" /quiet {1}", package, this.Configuration.UninstallPropertyReferences));
         }
 
         #endregion


### PR DESCRIPTION
The missing packages will be automatically downloaded during uninstall and improved logging for the shelled process of the msiexec.exe
